### PR TITLE
Add BlockNumber index to avoid lock wait timeouts.

### DIFF
--- a/database/entities.go
+++ b/database/entities.go
@@ -10,7 +10,7 @@ type Transaction struct {
 	Hash             string `gorm:"type:varchar(64);index;unique"`
 	FunctionSig      string `gorm:"type:varchar(50);index"`
 	Input            string `gorm:"type:string"`
-	BlockNumber      uint64
+	BlockNumber      uint64 `gorm:"index"`
 	BlockHash        string `gorm:"type:varchar(64)"`
 	TransactionIndex uint64
 	FromAddress      string `gorm:"type:varchar(40);index"`


### PR DESCRIPTION
The periodic drop history job searches for the first block after a specific timestamp. This is done in a transaction after some deletions, actually locking the table from other concurrent inserts. The transactions table has no index on BlockNumber used in the OrderBy clause, and MySQL is not able to use the Timestamp index on the Where clause to optimize the query, resulting in un-needed long table locks that sometimes exceed the MySQL lock wait timeout, causing fatal errors and indexer shutdown.